### PR TITLE
feat: find-id-page 문구 색 수정

### DIFF
--- a/src/pages/auth/FindIdPage.tsx
+++ b/src/pages/auth/FindIdPage.tsx
@@ -100,7 +100,7 @@ export default function FindIdPage() {
         setOkMsg("이미 해당 이메일로 회원가입되어 있습니다.");
       } else {
         // 가입되지 않은 이메일
-        setOkMsg("해당 이메일의 회원 정보가 없습니다.");
+        setErrorMsg("해당 이메일의 회원 정보가 없습니다.");
       }
     } catch (err) {
       console.error(err);

--- a/src/styles/auth/findIdStyles.ts
+++ b/src/styles/auth/findIdStyles.ts
@@ -97,7 +97,7 @@ export const findIdStyles = {
   success: {
     marginTop: "18px",
     fontSize: "13px",
-    color: "#4D4D4D",
+    color: "#0066FF",
     fontWeight: 500,
     lineHeight: 1.4,
   } as const,


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #96 

<br>

## 📝 작업 내용
**find-id-page 문구 색 수정**
 - 이메일의 존재 여부를 나타내는 문구 색 수정
   - 이메일 존재: 파랑
   - 이메일 존재 X: 빨강

<br>

## 📷 스크린샷
<img width="700" height="400" alt="image" src="https://github.com/user-attachments/assets/e012d601-f200-4683-80fd-b29f3f0c51a8" />



