### PR TITLE
chore: find-pw-page 닫힘 버튼 클릭 시 login-page로 이동하도록 수정

### DIFF
--- a/src/pages/auth/FindPasswordPage.tsx
+++ b/src/pages/auth/FindPasswordPage.tsx
@@ -126,7 +126,7 @@ export default function FindPasswordPage() {
           type="button"
           style={s.closeBtn}
           aria-label="나가기"
-          onClick={() => navigate("/login/help", { replace: true })}
+          onClick={() => navigate("/login", { replace: true })}
           disabled={isLoading}
         >
           <FindIdXIcon />


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #96 

<br>

## 📝 작업 내용
**find-pw-page 수정**
 - 기존 코드는 닫힘 버튼 클릭 시 login-help-page로 이동하는 것으로 되어 있었음
 - 피그마에 명시되어 있는 대로 login-page로 이동하도록 수정