### PR TITLE
Feat/reset password page

### DIFF
--- a/src/pages/auth/ResetPasswordPage.tsx
+++ b/src/pages/auth/ResetPasswordPage.tsx
@@ -6,11 +6,19 @@ import { getTextStyle } from "../../styles/auth/loginStyles";
 import { useMemo, useState } from "react";
 
 function isValidPassword(pw: string) {
+  // 8~32자 검증
   if (pw.length < 8 || pw.length > 32) return false;
+
+  // 영문, 숫자, 특수문자 조합 검증
   const hasLetter = /[A-Za-z]/.test(pw);
   const hasNumber = /[0-9]/.test(pw);
   const hasSpecial = /[^A-Za-z0-9]/.test(pw);
-  return hasLetter && hasNumber && hasSpecial;
+  const isCombined = hasLetter && hasNumber && hasSpecial;
+
+  // 3자 이상 연속된 동일 문자 및 숫자 제외 로직
+  const has3Reapting = /(.)\1{2,}/.test(pw);
+
+  return isCombined && !has3Reapting;
 }
 
 export default function ResetPasswordPage() {


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #96 

<br>

## 📝 작업 내용
**reset password page (1.1.2.3 비밀번호 찾기 4단계) 구현**
 - 비밀번호 8~32자 입력 가능, 3개 연속 불가, (영문, 숫자, 특수문자) 모두 포함 로직 구현
 - error 시 error message 강조 
 - 나가기 버튼, 확인 버튼 구현 완료
 - 백엔드 연동 시 mock 제거하고 변경 예정

<br>

## 📷 스크린샷
<img width="350" height="200" alt="image" src="https://github.com/user-attachments/assets/56c38a9d-ca05-4d61-a5d6-8f00c9708f15" />

<img width="350" height="200" alt="image" src="https://github.com/user-attachments/assets/b890db32-6a9f-429d-bb3f-1890e656efbb" />

<img width="350" height="200" alt="image" src="https://github.com/user-attachments/assets/e3c8a888-68f7-4f78-96d9-7113070871da" />
