### PR TITLE
feat: signup-page UI 구현 완료, 기본 로직 구현

### DIFF
--- a/src/pages/auth/SignupPage.tsx
+++ b/src/pages/auth/SignupPage.tsx
@@ -1,5 +1,342 @@
-export default function SignupPage () {
-    return (
-        <div>SignupPage</div>
-    )
+import { useMemo, useState } from "react";
+import { useNavigate } from "react-router-dom";
+import { signupStyles as s } from "../../styles/auth/signupStyles";
+import { getTextStyle } from "../../styles/auth/loginStyles";
+import QuestionIcon from "../../components/icons/QuestionIcon";
+import EmailBoxIcon from "../../components/icons/EmailBoxIcon";
+import FindIdXIcon from "../../components/icons/findIdXIcon";
+
+function isValidEmail(email: string) {
+  return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
+}
+function onlyDigits(v: string) {
+  return v.replace(/\D/g, "");
+}
+
+// mock: 백엔드 연동 전
+const mockSendEmailCode = async (_email: string) => {
+  await new Promise((r) => setTimeout(r, 500));
+  return { success: true as const, message: "인증번호를 전송했습니다." };
+};
+
+const mockVerifyEmailCode = async (_email: string, code: string) => {
+  await new Promise((r) => setTimeout(r, 500));
+  const ok = code === "123456";
+  return ok
+    ? { success: true as const, message: "인증이 완료되었습니다." }
+    : { success: false as const, message: "인증번호가 올바르지 않습니다." };
+};
+
+export default function SignupPage() {
+  const navigate = useNavigate();
+
+  // inputs
+  const [birth, setBirth] = useState(""); // 6자리
+  const [rr1, setRr1] = useState(""); // 1자리
+  const [email, setEmail] = useState("");
+  const [code, setCode] = useState("");
+
+  // states
+  const [isSending, setIsSending] = useState(false);
+  const [isVerifying, setIsVerifying] = useState(false);
+  const [sent, setSent] = useState(false);
+  const [verified, setVerified] = useState(false);
+
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [okMsg, setOkMsg] = useState<string | null>(null);
+
+  const birthOk = useMemo(() => birth.length === 6, [birth]);
+  const rr1Ok = useMemo(() => rr1.length === 1, [rr1]);
+  const emailOk = useMemo(() => isValidEmail(email.trim()), [email]);
+
+  const canSend = emailOk && !isSending;
+  const canVerify = sent && code.length === 6 && !isVerifying;
+  const canNext = birthOk && rr1Ok && verified;
+
+  const sendBtnStyle: React.CSSProperties = {
+    ...s.rightBtn,
+    ...(canSend ? {} : s.rightBtnDisabled),
+  };
+
+  const verifyBtnStyle: React.CSSProperties = {
+    ...s.rightBtn,
+    ...(canVerify ? {} : s.rightBtnDisabled),
+  };
+
+  const nextBtnStyle: React.CSSProperties = {
+    ...s.submitBase,
+    background: canNext ? "#0066FF" : "#3182F6",
+    ...(canNext ? {} : s.submitDisabled),
+  };
+
+  function handleClose() {
+    navigate("/login", { replace: true });
+  }
+
+  async function handleSend() {
+    setErrorMsg(null);
+    setOkMsg(null);
+
+    if (!emailOk) {
+      setErrorMsg("이메일 형식을 확인해 주세요.");
+      return;
+    }
+
+    setIsSending(true);
+    try {
+      // 실제 연동 시:
+      // await fetch("/auth/verify/email/send", { ... })
+      const res = await mockSendEmailCode(email.trim());
+      if (res.success) {
+        setSent(true);
+        setVerified(false);
+        setCode("");
+        setOkMsg("인증번호를 전송했습니다.");
+      }
+    } catch (e) {
+      console.error(e);
+      setErrorMsg("전송에 실패했습니다. 잠시 후 다시 시도해 주세요.");
+    } finally {
+      setIsSending(false);
+    }
+  }
+
+  async function handleVerify() {
+    setErrorMsg(null);
+    setOkMsg(null);
+
+    if (!sent) {
+      setErrorMsg("먼저 인증번호를 전송해 주세요.");
+      return;
+    }
+    if (code.length !== 6) {
+      setErrorMsg("인증번호 6자리를 입력해 주세요.");
+      return;
+    }
+
+    setIsVerifying(true);
+    try {
+      // 실제 연동 시:
+      // await fetch("/auth/verify/email/check", { ... })
+      const res = await mockVerifyEmailCode(email.trim(), code);
+      if (res.success) {
+        setVerified(true);
+        setOkMsg("인증이 완료되었습니다.");
+      } else {
+        setVerified(false);
+        setErrorMsg(res.message);
+      }
+    } catch (e) {
+      console.error(e);
+      setErrorMsg("인증 확인에 실패했습니다. 잠시 후 다시 시도해 주세요.");
+    } finally {
+      setIsVerifying(false);
+    }
+  }
+
+  function handleNext(e: React.FormEvent) {
+    e.preventDefault();
+    setErrorMsg(null);
+    setOkMsg(null);
+
+    if (!birthOk) {
+      setErrorMsg("생년월일 6자리를 입력해 주세요.");
+      return;
+    }
+    if (!rr1Ok) {
+      setErrorMsg("주민등록번호 뒤 1자리를 입력해 주세요.");
+      return;
+    }
+    if (!verified) {
+      setErrorMsg("이메일 인증을 완료해 주세요.");
+      return;
+    }
+    navigate("/signup/password");
+  }
+
+  return (
+    <div style={s.page}>
+      <div style={{ ...s.card, paddingTop: "50px" }}>
+        {/* 나가기 버튼 */}
+        <button
+          type="button"
+          style={s.closeBtn}
+          aria-label="나가기"
+          onClick={handleClose}
+        >
+            <FindIdXIcon />
+        </button>
+
+        {/* 제목 */}
+        <div style={s.title}>
+          <div style={{ ...getTextStyle(700, 22, "#000000"), lineHeight: 1.3 }}>
+            자주 사용하는 방법으로
+            <br />
+            시작하세요.
+          </div>
+        </div>
+
+        <form onSubmit={handleNext}>
+          {/* 생년월일 + 주민1 */}
+          <div style={s.fieldBlock}>
+            <div style={s.labelRow}>
+              <div style={getTextStyle(400, 12, "#4D4D4D")}>생년월일</div>
+            </div>
+
+            <div style={s.rowBirth}>
+              <div style={{ ...s.inputWrap, ...s.birthInput }}>
+                <input
+                  style={s.input}
+                  value={birth}
+                  onChange={(e) =>
+                    setBirth(onlyDigits(e.target.value).slice(0, 6))
+                  }
+                  placeholder="741205"
+                  inputMode="numeric"
+                  maxLength={6}
+                />
+              </div>
+
+              <div style={s.rowBirth}>
+                <div style={{ ...s.inputWrap, ...s.rrFrontWrap }}>
+                  <input
+                    style={{ ...s.input, ...s.rrFrontInput }}
+                    value={rr1}
+                    onChange={(e) =>
+                      setRr1(onlyDigits(e.target.value).slice(0, 1))
+                    }
+                    placeholder="1"
+                    inputMode="numeric"
+                    maxLength={1}
+                  />
+                </div>
+
+                <div style={s.rrMask}>
+                  <span>•</span>
+                  <span>•</span>
+                  <span>•</span>
+                  <span>•</span>
+                  <span>•</span>
+                  <span>•</span>
+                </div>
+              </div>
+            </div>
+          </div>
+
+          {/* 이메일 + 전송하기 */}
+          <div style={s.fieldBlock}>
+            <div style={s.labelRow}>
+              <div style={getTextStyle(400, 12, "#4D4D4D")}>
+                이메일{" "}
+                <div style={{ marginLeft: "3px" }}>
+                  <QuestionIcon />
+                </div>
+              </div>
+            </div>
+
+            <div style={s.rowEmail}>
+              <div style={s.emailInputWrap}>
+                <span style={s.leftIcon}>
+                  <EmailBoxIcon />
+                </span>
+                <input
+                  style={{ ...s.input, paddingLeft: 35 }}
+                  value={email}
+                  onChange={(e) => {
+                    setEmail(e.target.value);
+                    setSent(false);
+                    setVerified(false);
+                    setCode("");
+                  }}
+                  placeholder="example@naver.com"
+                  autoComplete="email"
+                  disabled={isSending || isVerifying}
+                />
+              </div>
+
+              <button
+                type="button"
+                style={sendBtnStyle}
+                onClick={handleSend}
+                disabled={!canSend}
+              >
+                {isSending ? "전송중" : "전송하기"}
+              </button>
+            </div>
+          </div>
+
+          {/* 인증번호 + 확인하기 */}
+          <div style={s.fieldBlock}>
+            <div style={s.labelRow}>
+              <div style={getTextStyle(400, 12, "#4D4D4D")}>
+                인증 번호 입력하기
+              </div>
+            </div>
+
+            <div style={s.rowVerify}>
+              <div style={s.emailInputWrap}>
+                <span style={s.leftIcon}>
+                  <EmailBoxIcon />
+                </span>
+                <input
+                  style={{ ...s.input, paddingLeft: 35 }}
+                  value={code}
+                  onChange={(e) =>
+                    setCode(onlyDigits(e.target.value).slice(0, 6))
+                  }
+                  placeholder="인증번호 6글자"
+                  inputMode="numeric"
+                  maxLength={6}
+                  disabled={!sent || verified || isVerifying}
+                />
+              </div>
+
+              <button
+                type="button"
+                style={verifyBtnStyle}
+                onClick={handleVerify}
+                disabled={!canVerify}
+              >
+                {isVerifying ? "확인중" : "확인하기"}
+              </button>
+            </div>
+          </div>
+
+          {/* 다음으로 */}
+          <button type="submit" style={nextBtnStyle} disabled={!canNext}>
+            <div style={getTextStyle(600, 14, "#FFFFFF")}>다음으로</div>
+          </button>
+        </form>
+
+        {/* 약관 */}
+        <div style={s.footer}>
+          <div style={s.agreeRow}>
+            <div style={{ flexShrink: 0 }}>
+              <QuestionIcon />
+            </div>
+            <div style={{ textAlign: "left" }}>
+              ‘다음으로’를 클릭하실 경우 인증을 위해 인증주체에서 요구하는
+              <br />
+              개인정보 수집 및 이용, 고유식별정보 처리, 서비스 이용약관,
+              <br />
+              통신사 이용약관, 개인정보 제3자 제공에 대한 동의합니다.
+            </div>
+          </div>
+          <div style={s.agreeRow}>
+            <div style={{ flexShrink: 0 }}>
+              <QuestionIcon />
+            </div>
+            <div style={{ textAlign: "left" }}>
+              계정 생성 시 서비스 이용을 위한 필수 항목인 서비스 이용약관과
+              <br />
+              개인정보 처리방침에 동의합니다.
+            </div>
+          </div>
+        </div>
+
+        {errorMsg && <div style={s.error}>{errorMsg}</div>}
+        {okMsg && <div style={s.success}>{okMsg}</div>}
+      </div>
+    </div>
+  );
 }

--- a/src/styles/auth/signupStyles.ts
+++ b/src/styles/auth/signupStyles.ts
@@ -1,0 +1,192 @@
+export const signupStyles = {
+    page: {
+        width: "100%",
+        height: "100vh",
+        position: "fixed",
+        top: 0,
+        left: 0,
+        overflow: "hidden",
+        display: "flex",
+        alignItems: "center",
+        justifyContent: "center",
+        background: "#f4f5fA",
+        padding: "24px",
+    } as const,
+
+    card: {
+        width: "400px",
+        background: "#FFFFFF",
+        borderRadius: "12px",
+        padding: "38px 45px 26px",
+        position: "relative",
+    } as const,
+
+    closeBtn: {
+        position: "absolute",
+        top: "16px",
+        right: "16px",
+        width: "28px",
+        height: "28px",
+        padding: 0,
+        border: "none",
+        background: "transparent",
+        cursor: "pointer",
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+    } as const,
+
+    title: {
+        textAlign: "center" as const,
+        marginBottom: "26px",
+    } as const,
+
+    fieldBlock: { marginBottom: "14px" } as const,
+
+    labelRow: {
+        display: "flex",
+        alignItems: "center",
+        marginBottom: "6px",
+        marginLeft: "8px",
+    } as const,
+
+    inputWrap: { position: "relative" as const } as const,
+
+    input: {
+        width: "100%",
+        height: "42px",
+        borderRadius: "10px",
+        border: "1px solid #E5E8EB",
+        padding: "0 12px",
+        outline: "none",
+        fontSize: "12px",
+        fontWeight: 400,
+        background: "#fff",
+    } as const,
+
+    leftIcon: {
+        position: "absolute",
+        left: "12px",
+        top: "50%",
+        transform: "translateY(-50%)",
+        display: "inline-flex",
+        alignItems: "center",
+        justifyContent: "center",
+        pointerEvents: "none",
+    } as const,
+
+    // 생년월일 + 주민1 자리 한 줄
+    rowBirth: {
+        display: "flex",
+        gap: "10px",
+        alignItems: "center",
+    } as const,
+
+    birthInput: {
+        flex: 1,
+    } as const,
+
+    rrFrontWrap: {
+        width: "62px",
+    } as const,
+
+    rrFrontInput: {
+        width: "62px",
+        textAlign: "center" as const,
+    } as const,
+
+    rrMask: {
+        display: "inline-flex",
+        gap: "6px",
+        alignItems: "center",
+        color: "#B0B8C1",
+        fontSize: "12px",
+        marginLeft: "2px",
+        userSelect: "none" as const,
+    } as const,
+
+    // 이메일 + 전송하기 한 줄
+    rowEmail: {
+        display: "flex",
+        gap: "10px",
+        alignItems: "center",
+    } as const,
+
+    emailInputWrap: {
+        flex: 1,
+        position: "relative" as const,
+    } as const,
+
+    rightBtn: {
+        width: "86px",
+        height: "42px",
+        borderRadius: "10px",
+        border: "1px solid #A7C5FF",
+        background: "#FFFFFF",
+        color: "#0066FF",
+        fontWeight: 600,
+        fontSize: "12px",
+        cursor: "pointer",
+    } as const,
+
+    rightBtnDisabled: {
+        opacity: 0.55,
+        cursor: "not-allowed",
+    } as const,
+
+    // 인증번호 + 확인하기 한 줄
+    rowVerify: {
+        display: "flex",
+        gap: "10px",
+        alignItems: "center",
+    } as const,
+
+    submitBase: {
+        width: "100%",
+        height: "44px",
+        borderRadius: "12px",
+        border: "none",
+        color: "#fff",
+        fontWeight: 700,
+        marginTop: "10px",
+        cursor: "pointer",
+    } as const,
+
+    submitDisabled: {
+        opacity: 0.65,
+        cursor: "not-allowed",
+    } as const,
+
+    footer: {
+        marginTop: "12px",
+        display: "flex",
+        flexDirection: "column" as const,
+        gap: "10px",
+    } as const,
+
+    agreeRow: {
+        display: "flex",
+        alignItems: "flex-start",
+        gap: "10px",
+        color: "#6F6F6F",
+        fontSize: "10px",
+        lineHeight: 1.4,
+        paddingLeft: "8px",
+    } as const,
+
+    error: {
+        marginTop: "10px",
+        fontSize: "12px",
+        color: "#d93025",
+        fontWeight: 600,
+        lineHeight: 1.4,
+    } as const,
+
+    success: {
+        marginTop: "10px",
+        fontSize: "12px",
+        color: "#2563eb",
+        fontWeight: 600,
+        lineHeight: 1.4,
+    } as const,
+};


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #97 

<br>

## 📝 작업 내용
**sign up page (1.2 이메일로 회원가입) 구현**
 - UI 구현 완료
 - 기본 로직 구현 
  - 나가기 버튼, 전송, 확인, 다음 버튼 구현
  - 세부 사항 수정 필요

<br>

## 📷 스크린샷
<img width="700" height="400" alt="image" src="https://github.com/user-attachments/assets/81b0275c-3677-42c9-989b-9ea4573068ed" />