### PR TITLE
feat: signup password page 로직 구현 및 UI 완성

### DIFF
--- a/src/pages/auth/SignupPasswordPage.tsx
+++ b/src/pages/auth/SignupPasswordPage.tsx
@@ -1,5 +1,248 @@
-export default function SignupPasswordPage () {
-    return (
-        <div>SignupPasswordPage</div>
-    )
+import { useNavigate } from "react-router-dom";
+import FindIdXIcon from "../../components/icons/findIdXIcon";
+import QuestionIcon from "../../components/icons/QuestionIcon";
+import { findIdStyles as s } from "../../styles/auth/findIdStyles";
+import { AUTH_KEY, getTextStyle } from "../../styles/auth/loginStyles";
+import { useMemo, useState } from "react";
+
+function isValidPassword(pw: string) {
+  // 8~32자 검증
+  if (pw.length < 8 || pw.length > 32) return false;
+
+  // 영문, 숫자, 특수문자 조합 검증
+  const hasLetter = /[A-Za-z]/.test(pw);
+  const hasNumber = /[0-9]/.test(pw);
+  const hasSpecial = /[^A-Za-z0-9]/.test(pw);
+  const isCombined = hasLetter && hasNumber && hasSpecial;
+
+  // 3자 이상 연속된 동일 문자 및 숫자 제외 로직
+  const has3Reapting = /(.)\1{2,}/.test(pw);
+
+  return isCombined && !has3Reapting;
+}
+
+/**
+ * 개발 중 mock:
+ * - 회원가입 성공 처리 -> 이어서 바로 로그인 처리
+ *
+ * 실제 연동 시:
+ * 1) /auth/signup/email
+ * 2) /auth/login/email 
+ * 순서로 fetch
+ */
+type SignupMockResponse = {
+  success: boolean;
+  message: string;
+  data?: { id: number };
+};
+
+const mockSignupAndLogin = (): Promise<SignupMockResponse> => {
+  return new Promise((resolve) => {
+    setTimeout(() => {
+      resolve({
+        success: true,
+        message: "요청이 성공적으로 처리되었습니다.",
+        data: { id: 1 },
+      });
+    }, 500);
+  });
+};
+
+export default function SignupPasswordPage() {
+  const navigate = useNavigate();
+
+  const [pw, setPw] = useState("");
+  const [pw2, setPw2] = useState("");
+  const [isPwInvalid, setIsPwInvalid] = useState(false);
+  const [errorMsg, setErrorMsg] = useState<string | null>(null);
+  const [isLoading, setIsLoading] = useState(false);
+
+  const pwOk = useMemo(() => isValidPassword(pw.trim()), [pw]);
+  const sameOk = useMemo(
+    () => pw.trim() !== "" && pw.trim() === pw2.trim(),
+    [pw, pw2],
+  );
+
+  const submitStyle: React.CSSProperties = {
+    ...s.submitBase,
+    background: "#3182F6",
+    cursor: "pointer",
+    marginTop: "18px",
+  };
+
+  function handleClose() {
+    navigate("/login", { replace: true });
+  }
+
+  async function handleSubmit(e: React.FormEvent) {
+    e.preventDefault();
+    setErrorMsg(null);
+
+    if (!pwOk) {
+      setIsPwInvalid(true);
+      return;
+    }
+    setIsPwInvalid(false);
+
+    if (!sameOk) {
+      setErrorMsg("위 작성된 비밀번호와 일치하지 않습니다.");
+      return;
+    }
+
+    // 백엔드 연동 시 
+    // 조건 만족 -> 회원가입 진행 -> 바로 로그인 -> 캘린더로 이동
+    setIsLoading(true);
+    try {
+        // 실제 연동 시 
+        // const res = await fetch("/auth/signup/email", { ... });
+        // if (!res.success) throw new Error("signup failed");
+        // const loginRes = await fetch("/auth/login/email", { ... });
+        // const result = await loginRes.json(); 
+        // ...
+
+        const result = await mockSignupAndLogin();
+
+        if (result.success && result.data) {
+          const payload = {
+            userId: result.data.id,
+            loggedInAt: Date.now(),
+          };
+          window.localStorage.setItem(AUTH_KEY, JSON.stringify(payload));
+
+          navigate("/dashboard", { replace: true });
+        } else {
+          setErrorMsg(result.message || "회원가입에 실패했습니다.");
+        }
+    } catch (err) {
+      console.error(err);
+      setErrorMsg("서버와의 연결에 실패했습니다. 잠시 후 다시 시도해 주세요.");
+    } finally {
+      setIsLoading(false);
+    }
+  }
+
+  const infoTextStyle: React.CSSProperties = {
+    color: isPwInvalid ? "#d93025" : "#6F6F6F",
+    textAlign: "left",
+    flex: 1,
+    fontSize: "11px",
+    lineHeight: 1.45,
+  };
+
+  return (
+    <div style={s.page}>
+      <div style={{ ...s.card, paddingTop: "80px" }}>
+        {/* X 나가기 버튼 */}
+        <button
+          type="button"
+          style={s.closeBtn}
+          aria-label="나가기"
+          onClick={handleClose}
+        >
+          <FindIdXIcon />
+        </button>
+
+        {/* 타이틀 */}
+        <div style={getTextStyle(700, 24, "#000000")}>
+          비밀번호를 입력하세요
+        </div>
+
+        <form onSubmit={handleSubmit}>
+          {/* 비밀번호 */}
+          <div style={{ ...s.fieldBlock, marginTop: "35px" }}>
+            <div style={{ ...s.labelRow, marginLeft: "8px" }}>
+              <div style={getTextStyle(400, 12, "#4D4D4D")}>비밀번호 </div>
+            </div>
+
+            <div style={s.inputWrap}>
+              <input
+                style={{ ...s.input }}
+                type="password"
+                value={pw}
+                onChange={(e) => setPw(e.target.value)}
+                placeholder=""
+                autoComplete="new-password"
+                maxLength={32}
+              />
+            </div>
+
+            {/* 안내문 */}
+            <div
+              style={{
+                marginTop: "10px",
+                display: "flex",
+              }}
+            >
+              <div
+                style={{
+                  marginLeft: "5px",
+                  marginRight: "6px",
+                  marginTop: "1px",
+                  flexShrink: 0,
+                }}
+              >
+                <QuestionIcon />
+              </div>
+              <div style={infoTextStyle}>
+                8자리 이상의 영문, 숫자, 특수문자 조합을 입력하세요.
+                <br />
+                (3자 이상의 연속된 동일 문자, 숫자로는 설정 불가합니다.)
+              </div>
+            </div>
+          </div>
+
+          {/* 비밀번호 확인 */}
+          <div style={{ ...s.fieldBlock, marginTop: "22px" }}>
+            <div style={{ ...s.labelRow, marginLeft: "8px" }}>
+              <div style={getTextStyle(400, 12, "#4D4D4D")}>비밀번호 확인</div>
+            </div>
+
+            <div style={s.inputWrap}>
+              <input
+                style={{ ...s.input }}
+                type="password"
+                value={pw2}
+                onChange={(e) => setPw2(e.target.value)}
+                placeholder=""
+                autoComplete="new-password"
+                maxLength={32}
+              />
+            </div>
+
+            {/* 안내문 */}
+            <div
+              style={{
+                marginTop: "10px",
+                fontSize: "11px",
+                color: "#6F6F6F",
+                lineHeight: 1.45,
+                display: "flex",
+              }}
+            >
+              <div
+                style={{
+                  marginLeft: "5px",
+                  marginRight: "6px",
+                  marginTop: "1px",
+                  flexShrink: 0,
+                }}
+              >
+                <QuestionIcon />
+              </div>
+              확인을 위해 입력하신 비밀번호를 다시 입력해 주세요.
+            </div>
+          </div>
+
+          {/* 확인 버튼 */}
+          <button type="submit" style={submitStyle}>
+            <div style={getTextStyle(600, 14, "#FFFFFF")}>확인</div>
+          </button>
+        </form>
+
+        {errorMsg && (
+          <div style={{ ...s.error, marginTop: "16px" }}>{errorMsg}</div>
+        )}
+      </div>
+    </div>
+  );
 }


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #97 

<br>

## 📝 작업 내용
**signup password page (1.2.1 이메일로 회원가입 비밀번호 입력)** 
 - 로직 구현 (1.1.2.3 비밀번호 찾기 4단계 페이지와 거의 동일)
   - 회원가입 시 로그인 + 대시보드로 이동하도록 설정

<br>

## 📷 스크린샷
<img width="1512" height="858" alt="image" src="https://github.com/user-attachments/assets/571e35a6-3f58-44e9-a168-ac7529057a22" />