### PR TITLE
feat: find-pw-page에 이메일 중복 확인 api 적용

### DIFF
--- a/src/pages/auth/FindPasswordPage.tsx
+++ b/src/pages/auth/FindPasswordPage.tsx
@@ -5,59 +5,17 @@ import EmailBoxIcon from "../../components/icons/EmailBoxIcon";
 import QuestionIcon from "../../components/icons/QuestionIcon";
 import { findIdStyles as s } from "../../styles/auth/findIdStyles";
 import { getTextStyle } from "../../styles/auth/loginStyles";
+import { useMutation } from "@tanstack/react-query";
+import { postEmailCheck } from "../../api/auth/auth";
 
 function isValidEmail(email: string) {
   return /^[^\s@]+@[^\s@]+\.[^\s@]+$/.test(email);
 }
 
-type EmailCheckSuccess = {
-  success: true;
-  message: string;
-  data: Record<string, never>;
-};
-
-type EmailCheckFail = {
-  success: false;
-  code: string;
-  message: string;
-  data: { id: number };
-};
-
-type EmailCheckResponse = EmailCheckSuccess | EmailCheckFail;
-
-/**
- * 개발 중 mock
- * - success:false => "이미 가입된 이메일입니다." (가입됨)
- * - success:true  => 가입된 이메일이 아님
- */
-const mockEmailCheckApi = (email: string): Promise<EmailCheckResponse> => {
-  return new Promise((resolve) => {
-    setTimeout(() => {
-      const isRegistered = email.trim().toLowerCase().endsWith("@naver.com");
-      if (isRegistered) {
-        resolve({
-          success: false,
-          code: "EMAIL_VEIFY400_1",
-          message: "이미 가입된 이메일입니다.",
-          data: { id: 1 },
-        });
-      } else {
-        resolve({
-          success: true,
-          message: "요청이 성공적으로 처리되었습니다.",
-          data: {},
-        });
-      }
-    }, 500);
-  });
-};
-
 export default function FindPasswordPage() {
   const navigate = useNavigate();
 
   const [email, setEmail] = useState("");
-  const [isLoading, setIsLoading] = useState(false);
-
   const [errorMsg, setErrorMsg] = useState<string | null>(null);
   const [okMsg, setOkMsg] = useState<string | null>(null);
 
@@ -66,6 +24,36 @@ export default function FindPasswordPage() {
     if (!isValidEmail(email.trim())) return false;
     return true;
   }, [email]);
+
+  const emailCheckMutation = useMutation({
+    mutationFn: () => postEmailCheck({ email: email.trim() }),
+    onSuccess: (result) => {
+      setErrorMsg(null);
+      setOkMsg(null);
+
+      if (result.isSuccess) {
+        setErrorMsg("해당 이메일의 회원 정보가 없습니다.");
+      }
+    },
+
+    // eslint-disable-next-line @typescript-eslint/no-explicit-any
+    onError: (error: any) => {
+      const status = error.response?.status;
+
+      if (status === 400 || status === 409) {
+        navigate("/login/find-password/verify", {
+          replace: true,
+          state: { email: email.trim() },
+        });
+      } else {
+        setErrorMsg("서버와의 연결에 실패했습니다.");
+      }
+
+      console.error("이메일 중복 에러 상세:", error.response?.data);
+    },
+  });
+
+  const isLoading = emailCheckMutation.isPending;
 
   const submitStyle: React.CSSProperties = {
     ...s.submitBase,
@@ -83,39 +71,7 @@ export default function FindPasswordPage() {
       return;
     }
 
-    setIsLoading(true);
-    try {
-      // 백엔드 연동 시:
-      // const response = await fetch("/members/email/check", {
-      //   method: "POST",
-      //   headers: {
-      //     "Content-Type": "application/json",
-      //     Authorization: `Bearer ${token}`,
-      //   },
-      //   body: JSON.stringify({ email: email.trim() }),
-      // });
-      // const result: EmailCheckResponse = await response.json();
-
-      const result = await mockEmailCheckApi(email);
-
-      // - 가입됨: success=false(이미 가입된 이메일입니다) => 다음 단계(인증번호 발송)로 이동 가능
-      // - 미가입: success=true => 안내만 띄우고 막기
-      if (result.success === false) {
-        setOkMsg("가입된 이메일입니다. 다음 단계로 진행할 수 있어요.");
-
-        navigate("/login/find-password/verify", {
-          replace: true,
-          state: { email: email.trim() },
-        });
-      } else {
-        setErrorMsg("해당 이메일의 회원 정보가 없습니다.");
-      }
-    } catch (err) {
-      console.error(err);
-      setErrorMsg("서버와의 연결에 실패");
-    } finally {
-      setIsLoading(false);
-    }
+    emailCheckMutation.mutate();
   }
 
   return (


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #96 

<br>

## 📝 작업 내용
**이메일 중복 확인 api 적용 (find-password-page)**
 - 사용자 이메일 입력 -> 이메일 중복 확인 
   - 중복 : 다음 페이지로 넘어감 (find-password-verify-page)
   - 중복 X :  회원 정보가 없다는 에러 메시지 출력