### PR TITLE
feat: 이메일 인증코드를 비밀번호 재설정 인증코드로 수정

### DIFF
--- a/src/api/auth/auth.ts
+++ b/src/api/auth/auth.ts
@@ -3,10 +3,10 @@ import {
     type EmailLoginRequest,
     type EmailCheckRequest,
     type EmailCheckResponse,
-    type EmailVerifyRequest,
-    type EmailVerifyResponse,
-    type EmailVerifyCheckRequest,
-    type EmailVerifyCheckResponse
+    type VerifyRequest,
+    type VerifyResponse,
+    type VerifyCheckRequest,
+    type VerifyCheckResponse
 } from "../../types/auth";
 import { axiosInstance } from "../core/axiosInstance";
 
@@ -22,14 +22,26 @@ export const postEmailCheck = async (body: EmailCheckRequest) => {
     return res.data;
 }
 
+// 비밀번호 재설정 인증코드 발송
+export const postPasswordVerifyCodeSend = async (body: VerifyRequest) => {
+    const res = await axiosInstance.post<VerifyResponse>("/api/auth/password/verification-codes", body);
+    return res.data;
+}
+
+// 비밀번호 재설정 인증코드 확인
+export const postPasswordVerifyCodeCheck = async (body: VerifyCheckRequest) => {
+    const res = await axiosInstance.post<VerifyCheckResponse>("/api/auth/password/verification-codes/verify", body);
+    return res.data;
+}
+
 // 이메일 인증코드 발송
-export const postEmailVerifyCodeSend = async (body: EmailVerifyRequest) => {
-    const res = await axiosInstance.post<EmailVerifyResponse>("/api/auth/email/verification-codes", body);
+export const postEmailVerifyCodeSend = async (body: VerifyRequest) => {
+    const res = await axiosInstance.post<VerifyResponse>("/api/auth/email/verification-codes", body);
     return res.data;
 }
 
 // 이메일 인증코드 확인
-export const postEmailVerifyCodeCheck = async (body: EmailVerifyCheckRequest) => {
-    const res = await axiosInstance.post<EmailVerifyCheckResponse>("/api/auth/email/verification-codes/verify", body);
+export const postEmailVerifyCodeCheck = async (body: VerifyCheckRequest) => {
+    const res = await axiosInstance.post<VerifyCheckResponse>("/api/auth/email/verification-codes/verify", body);
     return res.data;
 }

--- a/src/pages/auth/FindPasswordVerifyPage.tsx
+++ b/src/pages/auth/FindPasswordVerifyPage.tsx
@@ -7,8 +7,8 @@ import { findIdStyles as s } from "../../styles/auth/findIdStyles";
 import { getTextStyle } from "../../styles/auth/loginStyles";
 import { useMutation } from "@tanstack/react-query";
 import {
-  postEmailVerifyCodeCheck,
-  postEmailVerifyCodeSend,
+  postPasswordVerifyCodeCheck,
+  postPasswordVerifyCodeSend,
 } from "../../api/auth/auth";
 
 function isValidEmail(email: string) {
@@ -49,7 +49,7 @@ export default function FindPasswordVerifyPage() {
   }, [remainSec]);
 
   const verifiCodeSendMutation = useMutation({
-    mutationFn: () => postEmailVerifyCodeSend({ email: email.trim() }),
+    mutationFn: () => postPasswordVerifyCodeSend({ email: email.trim() }),
     onSuccess: (result) => {
       if (result.isSuccess) {
         setSendLocked(true);
@@ -71,7 +71,7 @@ export default function FindPasswordVerifyPage() {
 
   const verifiCodeCheckMutation = useMutation({
     mutationFn: () =>
-      postEmailVerifyCodeCheck({
+      postPasswordVerifyCodeCheck({
         email: email.trim(),
         "verify-code": code.trim(),
       }),

--- a/src/types/auth.ts
+++ b/src/types/auth.ts
@@ -34,39 +34,39 @@ export interface EmailCheckResponse {
     data: Record<string, never>;
 }
 
-// 이메일 인증코드 발송
-export interface EmailVerifyRequest {
+// 이메일 인증코드 발송 + 비밀번호 재설정 인증코드 발송
+export interface VerifyRequest {
     email: string;
 }
 
-export interface EmailVerifySuccessResonponse {
+export interface VerifySuccessResonponse {
     isSuccess: boolean;
     message: string;
 }
 
-export interface EmailVerifyErrorResonponse {
+export interface VerifyErrorResonponse {
     isSuccess: boolean;
     errorCode: string;
     message: string;
 }
 
-export type EmailVerifyResponse = EmailVerifySuccessResonponse | EmailVerifyErrorResonponse;
+export type VerifyResponse = VerifySuccessResonponse | VerifyErrorResonponse;
 
-// 이메일 인증코드 확인
-export interface EmailVerifyCheckRequest {
+// 이메일 인증코드 확인 + 비밀번호 재설정 인증코드 확인
+export interface VerifyCheckRequest {
     email: string;
     "verify-code": string;
 }
 
-export interface EmailVerifyCheckSuccessResponse {
+export interface VerifyCheckSuccessResponse {
     isSuccess: boolean;
     message: string;
 }
 
-export interface EmailVerifyCheckErrorResponse {
+export interface VerifyCheckErrorResponse {
     isSuccess: boolean;
     errorCode: string;
     message: string;
 }
 
-export type EmailVerifyCheckResponse = EmailVerifyCheckSuccessResponse | EmailVerifyCheckErrorResponse;
+export type VerifyCheckResponse = VerifyCheckSuccessResponse | VerifyCheckErrorResponse;


### PR DESCRIPTION
## 📝 작업 내용
 - 기존 : 이메일 인증코드 발송 및 확인 api로 잘못 작성함
 - 수정 후 : 비밀번호 재설정 인증코드 api로 교체

(이메일 인증코드 발송 및 확인과 비밀번호 재설정 인증코드 발송 및 확인 request, response body는 동일 -> 타입 공유)