### PR TITLE
chore: 개인정보 안내문 외부 링크 연결

### DIFF
--- a/src/components/setting/PrivacyAnalyticsPanel.tsx
+++ b/src/components/setting/PrivacyAnalyticsPanel.tsx
@@ -238,15 +238,24 @@ export default function PrivacyAnalyticsSettingPanel({
   const canSave = isChanged && !isLoading;
 
   function onClickInformation() {
-    alert("내 일정 학습 데이터 활용 동의 링크는 추후 연결 예정입니다.");
+    window.open(
+      "https://aquatic-battery-ff0.notion.site/30333e7fd7958044b1a5d38b7806c01c?pvs=74",
+      "_blank",
+    );
   }
 
   function onClickPrivacyPolicy() {
-    alert("개인정보 처리방침 링크는 추후 연결 예정입니다.");
+    window.open(
+      "https://aquatic-battery-ff0.notion.site/30233e7fd79580019784c1332a6c7cca",
+      "_blank",
+    );
   }
 
   function onClickServiceTerms() {
-    alert("서비스 이용 약관 링크는 추후 연결 예정입니다.");
+    window.open(
+      "https://aquatic-battery-ff0.notion.site/30233e7fd79580048d96e61697fb5622?pvs=74",
+      "_blank",
+    );
   }
 
   return (


### PR DESCRIPTION
## #️⃣ 연관된 이슈
> #101 

<br>

## 📝 작업 내용
 '설정 모달 - 개인정보 및 분석 설정 패널'에서
   - 내 일정 학습 데이터 활용 동의 안내문
   - 개인정보 처리방침
   - 서비스 이용 약관

클릭 시 각각에 해당하는 안내문 페이지가 새 탭에 생성되도록 외부 링크로 연결하였다. 

(기존에는 해당 안내문 페이지가 나오지 않은 상태였으므로 alert 처리하였다.)

=> 경고창을 외부 링크 연결로 교체